### PR TITLE
Fix a section level error in fdl.texi

### DIFF
--- a/doc/fdl.texi
+++ b/doc/fdl.texi
@@ -401,7 +401,7 @@ as a draft) by the Free Software Foundation.
 @end enumerate
 
 @page
-@appendixsubsec ADDENDUM: How to use this License for your documents
+@appendixsec ADDENDUM: How to use this License for your documents
 
 To use this License in a document you have written, include a copy of
 the License in the document and put the following copyright and


### PR DESCRIPTION
Fixes errors like:

```
./fdl.texi:404: raising the section level of @appendixsubsec which is too low
```

(Yes, I noticed it’s been 13 years since the last commit!)